### PR TITLE
Merge `recovery.img too large` workaround & fix for incorrect `responseCallList` in SamsungLegacyRIL

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -53,10 +53,6 @@ BOARD_GLOBAL_CFLAGS += -DSEC_PRODUCT_FEATURE_RIL_CALL_DUALMODE_CDMAGSM
 # Recovery
 TARGET_RECOVERY_FSTAB := $(LOCAL_PATH)/rootdir/etc/fstab.universal5410
 
-# Filesystems
-## Fix for recovery too large error when building
-BOARD_RECOVERYIMAGE_PARTITION_SIZE := 16777216
-
 # SELinux
 BOARD_SEPOLICY_DIRS += \
     device/samsung/ja3gduosctc/sepolicy
@@ -66,3 +62,7 @@ BOARD_SEPOLICY_DIRS += \
 
 # inherit common board flags
 include device/samsung/exynos5410-common/BoardConfigCommon.mk
+
+# Filesystems
+## (Workaround)Fix for recovery.img too large error when building
+BOARD_RECOVERYIMAGE_PARTITION_SIZE := 16777216

--- a/ril/telephony/java/com/android/internal/telephony/SamsungLegacyRIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/SamsungLegacyRIL.java
@@ -158,6 +158,7 @@ public class SamsungLegacyRIL extends RIL implements CommandsInterface {
         isGSM = (phoneType != RILConstants.CDMA_PHONE);
     }
 
+    @Override
     protected Object
     responseCallList(Parcel p) {
         int num;
@@ -177,27 +178,25 @@ public class SamsungLegacyRIL extends RIL implements CommandsInterface {
             dc = new DriverCall();
 
             dc.state = DriverCall.stateFromCLCC(p.readInt());
-            dc.index = p.readInt() & 0xff;
+            dc.index = p.readInt();
             dc.TOA = p.readInt();
             dc.isMpty = (0 != p.readInt());
             dc.isMT = (0 != p.readInt());
             dc.als = p.readInt();
             voiceSettings = p.readInt();
-            if (isGSM){
-                p.readInt();
-            }
             dc.isVoice = (0 == voiceSettings) ? false : true;
+
+            int type = p.readInt();
+            int domain = p.readInt();
+            String extras = p.readString();
+
             dc.isVoicePrivacy = (0 != p.readInt());
-            if (isGSM) {
-                p.readInt();
-                p.readInt();
-                p.readString();
-            }
             dc.number = p.readString();
-            int np = p.readInt();
-            dc.numberPresentation = DriverCall.presentationFromCLIP(np);
+            dc.numberPresentation = DriverCall.presentationFromCLIP(p.readInt());
             dc.name = p.readString();
-            dc.namePresentation = p.readInt();
+            Rlog.d(RILJ_LOG_TAG, "responseCallList dc.name = " + dc.name);
+
+            dc.namePresentation = DriverCall.presentationFromCLIP(p.readInt());
             int uusInfoPresent = p.readInt();
             if (uusInfoPresent == 1) {
                 dc.uusInfo = new UUSInfo();


### PR DESCRIPTION
*  (Workaround) Try to solve `recovery.img too large` error when building
* correct the implement of responseCallList in SamsungLegacyRIL




